### PR TITLE
camera stream view centered

### DIFF
--- a/src/app/add-offer-form/add-offer-form.tsx
+++ b/src/app/add-offer-form/add-offer-form.tsx
@@ -240,7 +240,7 @@ export function AddOfferForm() {
               color="primary"
               variant="contained"
             >
-              Abbrechen
+              Zurück zur Map
             </Button>
           </Stack>
         </Box>

--- a/src/app/add-offer-form/image/custom-webcam.tsx
+++ b/src/app/add-offer-form/image/custom-webcam.tsx
@@ -90,7 +90,7 @@ const CustomWebcam = ({
     >
       <Box sx={style}>
         <Stack direction="column">
-          <Stack justifyContent="center">
+          <Stack justifyContent="center" direction="row">
             {webcamLoading ? (
               <Box>
                 <Typography>Connecting...</Typography>


### PR DESCRIPTION
Mit diesem fix ist der Stream der Kamera schön in der Mitte. Sonst unschön links.